### PR TITLE
MNT: Add Matthew Feickert to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chrisburr @gartung @henryiii
+* @chrisburr @gartung @henryiii @matthewfeickert

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/README.md
+++ b/README.md
@@ -339,4 +339,5 @@ Feedstock Maintainers
 * [@chrisburr](https://github.com/chrisburr/)
 * [@gartung](https://github.com/gartung/)
 * [@henryiii](https://github.com/henryiii/)
+* [@matthewfeickert](https://github.com/matthewfeickert/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,3 +65,4 @@ extra:
     - henryiii
     - chrisburr
     - gartung
+    - matthewfeickert


### PR DESCRIPTION
Adding myself as a maintainer given @chrisburr's suggestion to use @conda-forge/hepmc3 as a metaorg team for [HEP Packaging Coordination](https://github.com/hep-packaging-coordination).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
   - Adding a maintainer doesn't require a rebuild.
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
