### PR TITLE
MNT: Add HEP Packaging Coordination team as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chrisburr @gartung @henryiii @matthewfeickert
+* @chrisburr @gartung @henryiii @kratsg @lgray @matthewfeickert @meiyasan @scarlehoff

--- a/README.md
+++ b/README.md
@@ -339,5 +339,9 @@ Feedstock Maintainers
 * [@chrisburr](https://github.com/chrisburr/)
 * [@gartung](https://github.com/gartung/)
 * [@henryiii](https://github.com/henryiii/)
+* [@kratsg](https://github.com/kratsg/)
+* [@lgray](https://github.com/lgray/)
 * [@matthewfeickert](https://github.com/matthewfeickert/)
+* [@meiyasan](https://github.com/meiyasan/)
+* [@scarlehoff](https://github.com/scarlehoff/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,7 @@ extra:
     - chrisburr
     - gartung
     - matthewfeickert
+    - kratsg
+    - lgray
+    - meiyasan
+    - scarlehoff


### PR DESCRIPTION
Add HEP Packaging Coordination team as of 2025-04-26 as maintainers so that https://github.com/conda-forge/hepmc3-feedstock can be used as a metaproject for team permissions.

Add @kratsg @lgray @meiyasan @scarlehoff

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
   - Not needed for adding team members.
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
