### PR TITLE
MNT: Patch to allow for modern CMake

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   patches:
     # c.f. https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/360
     - 0001-fallback-to-readlink-if-macOS-missing-greadlink.patch  # [osx]
+    - use-range-of-supported-cmake.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:

--- a/recipe/use-range-of-supported-cmake.patch
+++ b/recipe/use-range-of-supported-cmake.patch
@@ -1,0 +1,94 @@
+From c66a62925b8a8347204967118fe59aa802220d70 Mon Sep 17 00:00:00 2001
+From: Matthew Feickert <matthew.feickert@cern.ch>
+Date: Sun, 27 Apr 2025 23:58:40 -0600
+Subject: [PATCH] MNT: Use range of supported CMake versions
+
+* Use modern CMake syntax to support a range of supported CMake version
+  policies in cmake_minimum_required.
+   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+---
+ CMakeLists.txt                        | 2 +-
+ examples/BasicExamples/CMakeLists.txt | 2 +-
+ examples/CMakeLists.txt               | 2 +-
+ examples/SearchExample/CMakeLists.txt | 2 +-
+ python/CMakeLists.txt                 | 2 +-
+ test/CMakeLists.txt                   | 4 ++--
+ 6 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8de2c816..5c30debb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.1...3.31)
+ #----------------------------------------------------------------------------
+ project(HepMC3 LANGUAGES CXX)
+ set(PROJECT_VERSION 3.03.00)
+diff --git a/examples/BasicExamples/CMakeLists.txt b/examples/BasicExamples/CMakeLists.txt
+index e5f0e4ec..d918caa7 100644
+--- a/examples/BasicExamples/CMakeLists.txt
++++ b/examples/BasicExamples/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # building tests
+ #------------------
+-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.1...3.31)
+ #
+ 
+ #---Add executables------------------------------------------------------------
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index 7ccb03fc..067d4d5c 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # building examples
+ #------------------
+-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.1...3.31)
+ include_directories(${PROJECT_SOURCE_DIR}/include )
+ 
+ 
+diff --git a/examples/SearchExample/CMakeLists.txt b/examples/SearchExample/CMakeLists.txt
+index 5852644c..ebdb730b 100644
+--- a/examples/SearchExample/CMakeLists.txt
++++ b/examples/SearchExample/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # building tests
+ #------------------
+-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.1...3.31)
+ #
+ 
+ #---Add executables------------------------------------------------------------
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 888e17a4..02cdadd7 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ #project(pyHepMC3 CXX)
+ #Should be fixed
+-cmake_minimum_required(VERSION 3.5.0)
++cmake_minimum_required(VERSION 3.5...3.31)
+ if(${CMAKE_VERSION} VERSION_LESS "3.14.00")
+ SET_PROPERTY (GLOBAL PROPERTY CMAKE_ROLE "PROJECT")
+ endif()
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 0f6e50c7..61ef3fa5 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,9 +1,9 @@
+ #Beacause of LZMA targets
+ if (HEPMC3_TEST_LZMA)
+-  cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
++  cmake_minimum_required(VERSION 3.14...3.31)
+ endif()
+ if (HEPMC3_TEST_BZIP2)
+-  cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
++  cmake_minimum_required(VERSION 3.12...3.31)
+ endif()
+ 
+ 
+-- 
+2.49.0
+


### PR DESCRIPTION
* Add patch to allow for ranges of CMake versions.
   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
* Bump build number.
* Resolves #26 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
